### PR TITLE
Better naming of CSV files

### DIFF
--- a/csvcreator.py
+++ b/csvcreator.py
@@ -166,7 +166,7 @@ def main():
         # user set only the name
         elif name and not date:
             for table in getalltables(json_file):
-                createcsv(name + str(table), readdbtable(openjson(json_file),
+                createcsv(name, readdbtable(openjson(json_file),
                           str(table)))
         # user does not set any optional parameter
         else:


### PR DESCRIPTION
If you pass the argument ```--name``` but don't pass ```--date```, the code creates a csv file named after the concatenation of name and the date. I think this is the best way, since integrates nicely with our front-end.